### PR TITLE
ITCO-1032: Add postgresqlServer DNS zone mapping for Private Endpoints

### DIFF
--- a/virtual_network/private_endpoint_dns_zones.yml
+++ b/virtual_network/private_endpoint_dns_zones.yml
@@ -3,6 +3,7 @@ file: privatelink.file.core.windows.net
 queue: privatelink.queue.core.windows.net
 table: privatelink.table.core.windows.net
 mysqlServer: privatelink.mysql.database.azure.com
+postgresqlServer: privatelink.postgres.database.azure.com
 namespace: privatelink.servicebus.windows.net
 redisCache: privatelink.redis.cache.windows.net
 registry: privatelink.azurecr.io


### PR DESCRIPTION
Maps postgresqlServer subresource to privatelink.postgres.database.azure.com so PE DNS zone groups are auto-wired for PostgreSQL Flexible Servers.

Without this entry, creating a PostgreSQL Flexible Server PE produces no DNS zone group, so no A record is registered in the private DNS zone and clients cannot resolve the FQDN over VPN or private networks.