### PR TITLE
Add sites-staging to private endpoint DNS zone mapping

### DIFF
--- a/virtual_network/main.tf
+++ b/virtual_network/main.tf
@@ -74,7 +74,7 @@ locals {
 
   subresource_dns_zone_map = yamldecode(file("${path.module}/private_endpoint_dns_zones.yml"))
   subresource_names        = flatten([for k, v in local.config.subnets : [for i in v.private_endpoints : i.subresource_names if try(i.private_dns_zone_group.private_dns_zone_ids, null) == null]])
-  private_dns_zones        = flatten(values({ for k, v in local.subresource_dns_zone_map : k => v... if contains(local.subresource_names, k) }))
+  private_dns_zones        = flatten(values({ for k, v in local.subresource_dns_zone_map : k => v... if anytrue([for i in local.subresource_names : i == k || (startswith(i, trimsuffix(k, "*")) && endswith(k, "*"))]) }))
 }
 
 resource "azurecaf_name" "virtual_network" {
@@ -218,8 +218,11 @@ resource "azurerm_private_endpoint" "this" {
   tags                = local.config.tags
 
   private_dns_zone_group {
-    name                 = try(each.value.private_dns_zone_group.name, each.value.private_dns_zone_group, "default")
-    private_dns_zone_ids = try([for i in each.value.private_dns_zone_group.private_dns_zone_ids : try(azurerm_private_dns_zone.this[i].id, i)], compact(flatten([for k, v in local.subresource_dns_zone_map : [for i in flatten([v]) : try(azurerm_private_dns_zone.this[i].id, null)] if contains(flatten([each.value.subresource_names]), k)])))
+    name = try(each.value.private_dns_zone_group.name, each.value.private_dns_zone_group, "default")
+    private_dns_zone_ids = try(
+      [for i in each.value.private_dns_zone_group.private_dns_zone_ids : try(azurerm_private_dns_zone.this[i].id, i)],
+      compact(flatten([for k, v in local.subresource_dns_zone_map : [for i in flatten([v]) : try(azurerm_private_dns_zone.this[i].id, null)] if anytrue([for ii in flatten([each.value.subresource_names]) : ii == k || (startswith(ii, trimsuffix(k, "*")) && endswith(k, "*"))])]))
+    )
   }
 
   private_service_connection {

--- a/virtual_network/private_endpoint_dns_zones.yml
+++ b/virtual_network/private_endpoint_dns_zones.yml
@@ -20,6 +20,6 @@ hybridcompute:
   - privatelink.guestconfiguration.azure.com
   - privatelink.dp.kubernetesconfiguration.azure.com
 sites: privatelink.azurewebsites.net
-sites-staging: privatelink.azurewebsites.net
+sites-*: privatelink.azurewebsites.net
 Sql: privatelink.documents.azure.com
 Gateway: privatelink.azure-api.net

--- a/virtual_network/private_endpoint_dns_zones.yml
+++ b/virtual_network/private_endpoint_dns_zones.yml
@@ -20,5 +20,6 @@ hybridcompute:
   - privatelink.guestconfiguration.azure.com
   - privatelink.dp.kubernetesconfiguration.azure.com
 sites: privatelink.azurewebsites.net
+sites-staging: privatelink.azurewebsites.net
 Sql: privatelink.documents.azure.com
 Gateway: privatelink.azure-api.net


### PR DESCRIPTION
The subresource_dns_zone_map was missing a mapping for the App Service 'sites-staging' subresource. This caused private endpoints targeting deployment slot staging to be created without DNS zone groups, meaning no A records were registered in the privatelink.azurewebsites.net zone.
