### PR TITLE
Add account (Cognitive Services) to PE DNS zone mapping

### DIFF
--- a/virtual_network/private_endpoint_dns_zones.yml
+++ b/virtual_network/private_endpoint_dns_zones.yml
@@ -9,6 +9,7 @@ redisCache: privatelink.redis.cache.windows.net
 registry: privatelink.azurecr.io
 sqlServer: privatelink.database.windows.net
 vault: privatelink.vaultcore.azure.net
+account: privatelink.cognitiveservices.azure.com
 azuremonitor:
   - privatelink.monitor.azure.com
   - privatelink.oms.opinsights.azure.com


### PR DESCRIPTION
Maps the **account** subresource to \privatelink.cognitiveservices.azure.com\ for automatic DNS zone association on private endpoints targeting Azure Cognitive Services / AI Foundry resources.

Without this mapping, PEs using \subresource_names: [ account ]\ get \private_dns_zone_ids = []\ and DNS resolution fails (PE shows as Disconnected).