### PR TITLE
Fix: Create azurerm_function_app_connection for flex consumption too

### DIFF
--- a/app_service/main.tf
+++ b/app_service/main.tf
@@ -1856,7 +1856,7 @@ resource "azurerm_function_app_connection" "this" {
       for k, v in local.config.service_connections : k => merge(
         {
           name            = k
-          function_app_id = try(azurerm_linux_function_app.this.0, azurerm_windows_function_app.this.0).id
+          function_app_id = try(azurerm_linux_function_app.this.0, azurerm_windows_function_app.this.0, azapi_resource.flex_function.0).id
         },
         v
       ) if local.config.type == "FunctionApp"


### PR DESCRIPTION
## Problem
When migrating a Function App to Flex Consumption (\FC1\ SKU), \zurerm_linux_function_app.this\ gets \count=0\ (excluded by the FC SKU condition). The \or_each\ map in \zurerm_function_app_connection.this\ evaluates \unction_app_id\ using \	ry(azurerm_linux_function_app.this.0, azurerm_windows_function_app.this.0).id\, but both are empty tuples, so \	ry()\ fails at plan time.

## Fix
Add \zapi_resource.flex_function.0\ as a third fallback in the \	ry()\ call so the Flex Consumption resource ID is used when the regular function app is being replaced.

\\\hcl
# Before
function_app_id = try(azurerm_linux_function_app.this.0, azurerm_windows_function_app.this.0).id

# After
function_app_id = try(azurerm_linux_function_app.this.0, azurerm_windows_function_app.this.0, azapi_resource.flex_function.0).id
\\\

Discovered via failed vein prod deploy: https://github.com/kgknutsson/vein/actions/runs/26751655754/job/78841125298