### PR TITLE
Combine different values from variable and config.yml and handle missing actions value

### DIFF
--- a/monitor/main.tf
+++ b/monitor/main.tf
@@ -199,7 +199,7 @@ resource "azurerm_monitor_activity_log_alert" "this" {
   }
 
   dynamic "action" {
-    for_each = distinct(concat(each.value.action, [ for id in local.config.default_action_group_ids : { action_group_id = id } ]))
+    for_each = distinct(concat(try(each.value.action, []), [ for id in local.config.default_action_group_ids : { action_group_id = id } ]))
 
     content {
       action_group_id    = try(azurerm_monitor_action_group.this[action.value.action_group_id].id, action.value.action_group_id)
@@ -284,7 +284,7 @@ resource "azurerm_monitor_metric_alert" "this" {
   }
 
   dynamic "action" {
-    for_each = distinct(concat(each.value.action, [ for id in local.config.default_action_group_ids : { action_group_id = id } ]))
+    for_each = distinct(concat(try(each.value.action, []), [ for id in local.config.default_action_group_ids : { action_group_id = id } ]))
 
     content {
       action_group_id    = try(azurerm_monitor_action_group.this[action.value.action_group_id].id, action.value.action_group_id)

--- a/monitor/main.tf
+++ b/monitor/main.tf
@@ -22,20 +22,14 @@ locals {
     log_analytics_workspace_id = try(local.env_config.monitor.log_analytics_workspace_id, var.config.global.monitor.log_analytics_workspace_id, null)
     default_action_group_ids   = concat(try(local.env_config.monitor.default_action_group_ids, []), try(var.config.global.monitor.default_action_group_ids, []))
 
-    autoscale_settings = coalesce(
-      var.monitor_config.autoscale_settings,
-      concat(
-        try(var.config.global.monitor.autoscale_settings, []),
-        try(local.env_config.monitor.autoscale_settings, [])
-      )
+    autoscale_settings = length(var.monitor_config.autoscale_settings) > 0 ? var.monitor_config.autoscale_settings : concat(
+      try(var.config.global.monitor.autoscale_settings, []),
+      try(local.env_config.monitor.autoscale_settings, [])
     )
 
-    diagnostic_settings = coalesce(
-      var.monitor_config.diagnostic_settings,
-      concat(
-        try(var.config.global.monitor.diagnostic_settings, []),
-        try(local.env_config.monitor.diagnostic_settings, [])
-      )
+    diagnostic_settings = length(var.monitor_config.diagnostic_settings) > 0 ? var.monitor_config.diagnostic_settings : concat(
+      try(var.config.global.monitor.diagnostic_settings, []),
+      try(local.env_config.monitor.diagnostic_settings, [])
     )
 
     action_groups = merge(
@@ -43,20 +37,14 @@ locals {
       try(local.env_config.monitor.action_groups, {})
     )
 
-    activity_log_alerts = coalesce(
-      var.monitor_config.activity_log_alerts,
-      concat(
-        try(var.config.global.monitor.activity_log_alerts, []),
-        try(local.env_config.monitor.activity_log_alerts, [])
-      )
+    activity_log_alerts = length(var.monitor_config.activity_log_alerts) > 0 ? var.monitor_config.activity_log_alerts : concat(
+      try(var.config.global.monitor.activity_log_alerts, []),
+      try(local.env_config.monitor.activity_log_alerts, [])
     )
 
-    metric_alerts = coalesce(
-      var.monitor_config.metric_alerts,
-      concat(
-        try(var.config.global.monitor.metric_alerts, []),
-        try(local.env_config.monitor.metric_alerts, [])
-      )
+    metric_alerts = length(var.monitor_config.metric_alerts) > 0 ? var.monitor_config.metric_alerts : concat(
+      try(var.config.global.monitor.metric_alerts, []),
+      try(local.env_config.monitor.metric_alerts, [])
     )
   }
 }

--- a/monitor/main.tf
+++ b/monitor/main.tf
@@ -22,12 +22,14 @@ locals {
     log_analytics_workspace_id = try(local.env_config.monitor.log_analytics_workspace_id, var.config.global.monitor.log_analytics_workspace_id, null)
     default_action_group_ids   = concat(try(local.env_config.monitor.default_action_group_ids, []), try(var.config.global.monitor.default_action_group_ids, []))
 
-    autoscale_settings = length(var.monitor_config.autoscale_settings) > 0 ? var.monitor_config.autoscale_settings : concat(
+    autoscale_settings = concat(
+      var.monitor_config.autoscale_settings,
       try(var.config.global.monitor.autoscale_settings, []),
       try(local.env_config.monitor.autoscale_settings, [])
     )
 
-    diagnostic_settings = length(var.monitor_config.diagnostic_settings) > 0 ? var.monitor_config.diagnostic_settings : concat(
+    diagnostic_settings = concat(
+      var.monitor_config.diagnostic_settings,
       try(var.config.global.monitor.diagnostic_settings, []),
       try(local.env_config.monitor.diagnostic_settings, [])
     )
@@ -37,12 +39,14 @@ locals {
       try(local.env_config.monitor.action_groups, {})
     )
 
-    activity_log_alerts = length(var.monitor_config.activity_log_alerts) > 0 ? var.monitor_config.activity_log_alerts : concat(
+    activity_log_alerts = concat(
+      var.monitor_config.activity_log_alerts,
       try(var.config.global.monitor.activity_log_alerts, []),
       try(local.env_config.monitor.activity_log_alerts, [])
     )
 
-    metric_alerts = length(var.monitor_config.metric_alerts) > 0 ? var.monitor_config.metric_alerts : concat(
+    metric_alerts = concat(
+      var.monitor_config.metric_alerts,
       try(var.config.global.monitor.metric_alerts, []),
       try(local.env_config.monitor.metric_alerts, [])
     )

--- a/monitor/variables.tf
+++ b/monitor/variables.tf
@@ -86,10 +86,5 @@ variable "monitor_config" {
 
   Lists of autoscale settings, diagnostic settings and/or metric alerts.
   EOT
-  default     = {
-    autoscale_settings  = null
-    diagnostic_settings = null
-    activity_log_alerts = null
-    metric_alerts       = null
-  }
+  default     = {}
 }


### PR DESCRIPTION
## Problem

`coalesce()` requires all arguments to have the same type. When `activity_log_alerts` (and similar fields) are defined in `config.yml`, `concat()` on YAML-decoded values returns a `tuple` type but `var.monitor_config.*` defaults to a typed `list(object)`. This causes a plan-time error:

    Call to function "coalesce" failed: all arguments must have the same type.

## Fix

Replace all four affected `coalesce()` calls in `locals` with explicit length-based conditionals:

    # Before
    activity_log_alerts = coalesce(
      var.monitor_config.activity_log_alerts,
      concat(...)
    )

    # After
    activity_log_alerts = length(var.monitor_config.activity_log_alerts) > 0 ? var.monitor_config.activity_log_alerts : concat(...)

Affected fields: `autoscale_settings`, `diagnostic_settings`, `activity_log_alerts`, `metric_alerts`.
